### PR TITLE
add "sbx help <cmd>"; parse command args

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ To cut a new release, [publish a new tag](https://github.com/reverbdotcom/sbx/re
 Every command should be a go package. Commands are
 configured in `commands/commands.go`.
 
-
 `make <command>.run` will build and run the command.
 This runs live.
 

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -4,6 +4,7 @@ import (
 	"github.com/reverbdotcom/sbx/dash"
 	"github.com/reverbdotcom/sbx/down"
 	"github.com/reverbdotcom/sbx/graphiql"
+	"github.com/reverbdotcom/sbx/help"
 	"github.com/reverbdotcom/sbx/logs"
 	"github.com/reverbdotcom/sbx/name"
 	"github.com/reverbdotcom/sbx/summary"
@@ -12,57 +13,14 @@ import (
 	"github.com/reverbdotcom/sbx/web"
 )
 
-type RunFn func() (string, error)
-
-const Help = `NAME
-  sbx - orchestra cli
-
-COMMANDS
-
-  sbx help
-      up
-      down
-      name
-      dash
-      logs
-      web
-      graphiql
-      version
-      info
-      progress
-
-DESCRIPTION
-
-  command     shorthand     description
-
-  help        h             show the help message.
-  up          u             spin up an orchestra sandbox.
-  down                      tear down an orchestra sandbox.
-  name        n             show the sandbox name.
-  dash        d             open the dashboard in a browser.
-  logs        l             open the logs in a browser.
-  web         w             open the site in a browser.
-  graphiql    g             open graphql user interface in a browser.
-  version     v             show the version of the sbx cli.
-  info        i             show the summary of the sandbox.
-  progress    p             open deployment progress in a browser.
-
-USAGE:
-
-  sbx up
-  sbx name
-`
-
-func help() (string, error) {
-	return Help, nil
-}
+type RunFn func(cmdArgs []string) (string, error)
 
 func Commands() map[string]RunFn {
 	return map[string]RunFn{
 		"up":       up.Run,
 		"u":        up.Run,
-		"help":     help,
-		"h":        help,
+		"help":     help.Run,
+		"h":        help.Run,
 		"name":     name.Run,
 		"n":        name.Run,
 		"web":      web.Open,

--- a/dash/dash.go
+++ b/dash/dash.go
@@ -11,7 +11,7 @@ const template = "https://app.datadoghq.com/dashboard/9rm-fjs-8tx/orchestra?tpl_
 
 var openURL = open.Open
 
-func Run() (string, error) {
+func Run(_ []string) (string, error) {
 	err := openURL(Url())
 
 	if err != nil {

--- a/dash/dash_test.go
+++ b/dash/dash_test.go
@@ -35,7 +35,7 @@ func TestRun(t *testing.T) {
 			return nil
 		}
 
-		_, err := Run()
+		_, err := Run([]string{})
 
 		if err != nil {
 			t.Errorf("got %v, want nil", err)
@@ -47,7 +47,7 @@ func TestRun(t *testing.T) {
 			return errors.New("open error")
 		}
 
-		_, err := Run()
+		_, err := Run([]string{})
 
 		want := "open error"
 		if err.Error() != want {

--- a/down/down.go
+++ b/down/down.go
@@ -10,7 +10,7 @@ import (
 var nameFn = name.Name
 var teardownSandboxFn = github.TeardownSandbox
 
-func Run() (string, error) {
+func Run(_ []string) (string, error) {
 	name, err := nameFn()
 
 	if err != nil {

--- a/down/down_test.go
+++ b/down/down_test.go
@@ -10,7 +10,7 @@ func TestRun(t *testing.T) {
 		nameFn = func() (string, error) { return "sandbox-blake-julian-kevin", nil }
 		teardownSandboxFn = func(_ string) error { return nil }
 
-		_, err := Run()
+		_, err := Run([]string{})
 
 		if err != nil {
 			t.Errorf("got %v", err)
@@ -23,7 +23,7 @@ func TestRun(t *testing.T) {
 		want := errors.New("name error")
 		nameFn = func() (string, error) { return "", want }
 
-		_, err := Run()
+		_, err := Run([]string{})
 
 		if err.Error() != want.Error() {
 			t.Errorf("got %v", err)
@@ -36,7 +36,7 @@ func TestRun(t *testing.T) {
 		want := errors.New("teardown error")
 		teardownSandboxFn = func(_ string) error { return want }
 
-		_, err := Run()
+		_, err := Run([]string{})
 
 		if err.Error() != want.Error() {
 			t.Errorf("got %v", err)

--- a/graphiql/graphiql.go
+++ b/graphiql/graphiql.go
@@ -11,7 +11,7 @@ const template = "https://graphiql-%s.int.orchestra.rvb.ai/graphql"
 
 var openURL = open.Open
 
-func Run() (string, error) {
+func Run(_ []string) (string, error) {
 	err := openURL(Url())
 
 	if err != nil {

--- a/graphiql/graphiql_test.go
+++ b/graphiql/graphiql_test.go
@@ -35,7 +35,7 @@ func TestRun(t *testing.T) {
 			return nil
 		}
 
-		_, err := Run()
+		_, err := Run([]string{})
 
 		if err != nil {
 			t.Errorf("got %v, want nil", err)
@@ -47,7 +47,7 @@ func TestRun(t *testing.T) {
 			return errors.New("open error")
 		}
 
-		_, err := Run()
+		_, err := Run([]string{})
 
 		want := "open error"
 		if err.Error() != want {

--- a/help/help.go
+++ b/help/help.go
@@ -1,0 +1,73 @@
+package help
+
+import (
+	"fmt"
+
+	"github.com/reverbdotcom/sbx/up"
+)
+
+type HelpFn func() (string, error)
+
+const Help = `NAME
+  sbx - orchestra cli
+
+COMMANDS
+
+  sbx help
+      up
+      down
+      name
+      dash
+      logs
+      web
+      graphiql
+      version
+      info
+      progress
+
+DESCRIPTION
+
+  command     shorthand     description
+
+  help        h             show the help message. use "sbx help <cmd>" for more info about that command.
+  up          u             spin up an orchestra sandbox.
+  down                      tear down an orchestra sandbox.
+  name        n             show the sandbox name.
+  dash        d             open the dashboard in a browser.
+  logs        l             open the logs in a browser.
+  web         w             open the site in a browser.
+  graphiql    g             open graphql user interface in a browser.
+  version     v             show the version of the sbx cli.
+  info        i             show the summary of the sandbox.
+  progress    p             open deployment progress in a browser.
+
+USAGE:
+
+  sbx up
+  sbx name
+`
+
+func Run(cmdArgs []string) (string, error) {
+	var totalArgs = len(cmdArgs)
+	if totalArgs == 0 {
+		return Help, nil
+	}
+
+	if totalArgs > 1 {
+		return "", fmt.Errorf("too many arguments")
+	}
+
+	var cmd = cmdArgs[0]
+	var helpFn = helps()[cmd]
+	if helpFn == nil {
+		return fmt.Sprintf("no help info available for command %s", cmd), nil
+	}
+
+	return helpFn()
+}
+
+func helps() map[string]HelpFn {
+	return map[string]HelpFn{
+		"up": up.Help,
+	}
+}

--- a/help/help_test.go
+++ b/help/help_test.go
@@ -1,0 +1,52 @@
+package help
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/reverbdotcom/sbx/up"
+)
+
+func TestRun(t *testing.T) {
+	t.Run("it returns generic help text with no args", func(t *testing.T) {
+		output, err := Run([]string{})
+
+		if err != nil {
+			t.Errorf("unexpected error %v", err)
+		}
+
+		if output != Help {
+			t.Errorf("did not return generic help text, got %v", output)
+		}
+	})
+
+	t.Run("it fails when there's too many args", func(t *testing.T) {
+		output, err := Run([]string{"up", "foo"})
+		if err == nil {
+			t.Errorf("help should have errored, but got %v", output)
+		}
+	})
+
+	t.Run("it returns help text for command", func(t *testing.T) {
+		output, err := Run([]string{"up"})
+		if err != nil {
+			t.Errorf("unexpected error %v", err)
+		}
+
+		text, _ := up.Help()
+		if output != text {
+			t.Errorf("did not return help text for up, got %v", output)
+		}
+	})
+
+	t.Run("it reports when command has no help info", func(t *testing.T) {
+		output, err := Run([]string{"foo"})
+		if err != nil {
+			t.Errorf("unexpected error %v", err)
+		}
+
+		if !strings.Contains(output, "no help info") {
+			t.Errorf("expected to report no help info for command, but got %v", output)
+		}
+	})
+}

--- a/logs/log.go
+++ b/logs/log.go
@@ -13,7 +13,7 @@ const template = "https://app.datadoghq.com/logs?query=version:1.0.0-sha-%v%%20k
 
 var openURL = open.Open
 
-func Run() (string, error) {
+func Run(_ []string) (string, error) {
 	err := openURL(Url())
 
 	if err != nil {

--- a/logs/log_test.go
+++ b/logs/log_test.go
@@ -42,7 +42,7 @@ func TestRun(t *testing.T) {
 			return nil
 		}
 
-		_, err := Run()
+		_, err := Run([]string{})
 
 		if err != nil {
 			t.Errorf("got %v, want nil", err)
@@ -54,7 +54,7 @@ func TestRun(t *testing.T) {
 			return errors.New("open error")
 		}
 
-		_, err := Run()
+		_, err := Run([]string{})
 
 		want := "open error"
 		if err.Error() != want {

--- a/name/name.go
+++ b/name/name.go
@@ -14,7 +14,7 @@ import (
 const maxStep = 2
 const sandbox = "sandbox-"
 
-func Run() (string, error) {
+func Run(_ []string) (string, error) {
 	return Name()
 }
 

--- a/name/name_test.go
+++ b/name/name_test.go
@@ -14,7 +14,7 @@ func TestRun(t *testing.T) {
 			return "nn-sbx-1234", nil
 		}
 
-		got, err := Run()
+		got, err := Run([]string{})
 		want := "sandbox-blake-julian-kevin"
 
 		if err != nil {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -6,27 +6,38 @@ import (
 
 	"github.com/reverbdotcom/sbx/check"
 	"github.com/reverbdotcom/sbx/commands"
+	"github.com/reverbdotcom/sbx/help"
 	"golang.org/x/exp/slices"
 )
 
-func Parse(args []string) (*commands.RunFn, error) {
-	cmd, err := command(args)
+func Parse(args []string) (*commands.RunFn, []string, error) {
+	cmd, cmdArgs, err := command(args)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return cmdfn(*cmd)
+	cmdFn, err := cmdfn(*cmd)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return cmdFn, cmdArgs, nil
 }
 
-func command(args []string) (command *string, err error) {
+func command(args []string) (command *string, commandArgs []string, err error) {
 	if len(args) < 2 {
-		return nil, errr("command required")
+		return nil, nil, errr("command required")
 	}
 
 	cmd := args[1]
 
-	return &cmd, nil
+	cmdArgs := []string{}
+	if len(args) > 2 {
+		cmdArgs = args[2:]
+	}
+
+	return &cmd, cmdArgs, nil
 }
 
 var ensureOrchestra = check.EnsureOrchestra
@@ -55,5 +66,5 @@ func cmdfn(command string) (*commands.RunFn, error) {
 }
 
 func errr(message string) error {
-	return errors.New(fmt.Sprintf("%s\n\n\n%s", message, commands.Help))
+	return errors.New(fmt.Sprintf("%s\n\n\n%s", message, help.Help))
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -10,7 +10,7 @@ func TestParse(t *testing.T) {
 	t.Run("it returns up command", func(t *testing.T) {
 		ensureOrchestra = func() error { return nil }
 		args := []string{"sbx", "up"}
-		cmdfn, err := Parse(args)
+		cmdfn, _, err := Parse(args)
 
 		if err != nil {
 			t.Errorf("got %v, want nil", err)
@@ -21,10 +21,24 @@ func TestParse(t *testing.T) {
 		}
 	})
 
+	t.Run("it returns command args", func(t *testing.T) {
+		ensureOrchestra = func() error { return nil }
+		args := []string{"sbx", "help", "up"}
+		_, cmdArgs, err := Parse(args)
+
+		if err != nil {
+			t.Errorf("got %v, want nil", err)
+		}
+
+		if cmdArgs == nil || len(cmdArgs) != 1 || cmdArgs[0] != "up" {
+			t.Errorf("got %v, want %v", cmdArgs, []string{"up"})
+		}
+	})
+
 	t.Run("it errs when no command is provided", func(t *testing.T) {
 		ensureOrchestra = func() error { return nil }
 		args := []string{"sbx"}
-		cmdfn, err := Parse(args)
+		cmdfn, _, err := Parse(args)
 
 		if err == nil {
 			t.Errorf("got nil, want error")
@@ -43,7 +57,7 @@ func TestParse(t *testing.T) {
 	t.Run("it errs when command is not found", func(t *testing.T) {
 		ensureOrchestra = func() error { return nil }
 		args := []string{"sbx", "does-not-exist"}
-		cmdfn, err := Parse(args)
+		cmdfn, _, err := Parse(args)
 
 		if err == nil {
 			t.Errorf("got nil, want error")
@@ -63,7 +77,7 @@ func TestParse(t *testing.T) {
 		ensureOrchestra = func() error { return errors.New("This project is not on Orchestra.") }
 
 		args := []string{"sbx", "up"}
-		_, err := Parse(args)
+		_, _, err := Parse(args)
 
 		want := "This project is not on Orchestra."
 		if err.Error() != want {
@@ -83,7 +97,7 @@ func TestParse(t *testing.T) {
 			ensureOrchestra = func() error { return errors.New("This project is not on Orchestra.") }
 
 			args := []string{"sbx", cmd}
-			_, err := Parse(args)
+			_, _, err := Parse(args)
 
 			if err != nil {
 				t.Errorf("got %v, want nil, for cmd %s", err, cmd)

--- a/sbx.go
+++ b/sbx.go
@@ -9,11 +9,11 @@ import (
 )
 
 func main() {
-	cmdfn, err := parser.Parse(os.Args)
+	cmdfn, cmdArgs, err := parser.Parse(os.Args)
 	onError(err)
 
 	fn := *cmdfn
-	out, err := fn()
+	out, err := fn(cmdArgs)
 	fmt.Println(out)
 	onError(err)
 }

--- a/summary/summary.go
+++ b/summary/summary.go
@@ -26,7 +26,7 @@ Graphiql:   %s
 View deployment, run: 'sbx p'
 `
 
-func Run() (string, error) {
+func Run(_ []string) (string, error) {
 	name, err := name.Name()
 
 	if err != nil {

--- a/up/up.go
+++ b/up/up.go
@@ -30,7 +30,7 @@ var nameFn = name.Name
 var htmlUrlFn = run.HtmlUrl
 var summaryFn = summary.Print
 
-func Run() (string, error) {
+func Run(_ []string) (string, error) {
 	fmt.Println("deploying...")
 	fmt.Println()
 
@@ -149,4 +149,13 @@ func onSandbox(name string) (bool, error) {
 	yes := strings.TrimSpace(out) == name
 
 	return yes, nil
+}
+
+func Help() (string, error) {
+	return `USAGE:
+sbx up
+
+DESCRIPTION:
+spin up an orchestra sandbox.`,
+		nil
 }

--- a/up/up_test.go
+++ b/up/up_test.go
@@ -23,7 +23,7 @@ func TestRun(t *testing.T) {
 		}
 
 		cmdFn = cli.MockCmd(t, wants)
-		_, err := Run()
+		_, err := Run([]string{})
 
 		if err.Error() != "cannot deploy from main branch" {
 			t.Errorf("got %v", err.Error())
@@ -44,7 +44,7 @@ func TestRun(t *testing.T) {
 			return "sandbox-blake-julian-kevin", errors.New("name error")
 		}
 
-		_, err := Run()
+		_, err := Run([]string{})
 
 		if err.Error() != "name error" {
 			t.Errorf("got %v", err.Error())
@@ -81,7 +81,7 @@ func TestRun(t *testing.T) {
 
 		cmdFn = cli.MockCmd(t, wants)
 
-		_, err := Run()
+		_, err := Run([]string{})
 
 		if err != nil {
 			t.Errorf("got %v, want nil", err)
@@ -109,7 +109,7 @@ func TestRun(t *testing.T) {
 
 		cmdFn = cli.MockCmd(t, wants)
 
-		_, err := Run()
+		_, err := Run([]string{})
 
 		if err.Error() != wants[2].Err.Error() {
 			t.Errorf("got %v, want %v", err, wants[2].Err)
@@ -142,7 +142,7 @@ func TestRun(t *testing.T) {
 
 		cmdFn = cli.MockCmd(t, wants)
 
-		_, err := Run()
+		_, err := Run([]string{})
 
 		if err != wants[3].Err {
 			t.Errorf("got %v, want %v", err, wants[3].Err)
@@ -195,7 +195,7 @@ func TestRun(t *testing.T) {
 
 		cmdFn = cli.MockCmd(t, wants)
 
-		_, err := Run()
+		_, err := Run([]string{})
 
 		if err != nil {
 			t.Errorf("got %v, want nil", err)
@@ -228,7 +228,7 @@ func TestRun(t *testing.T) {
 
 		cmdFn = cli.MockCmd(t, wants)
 
-		_, err := Run()
+		_, err := Run([]string{})
 
 		if err != nil {
 			t.Errorf("got %v, want nil", err)
@@ -260,7 +260,7 @@ func TestRun(t *testing.T) {
 
 		cmdFn = cli.MockCmd(t, wants)
 
-		_, err := Run()
+		_, err := Run([]string{})
 
 		if err != nil {
 			t.Errorf("got %v, want nil", err)

--- a/version/version.go
+++ b/version/version.go
@@ -9,6 +9,6 @@ import (
 //go:embed SBX_VERSION
 var version string
 
-func Run() (string, error) {
+func Run(_ []string) (string, error) {
 	return fmt.Sprintf("Version: %s\n", strings.TrimSpace(version)), nil
 }

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -8,7 +8,7 @@ func TestRun(t *testing.T) {
 	t.Run("it returns version", func(t *testing.T) {
 		version = "v1.0.0"
 
-		got, err := Run()
+		got, err := Run([]string{})
 		want := "Version: v1.0.0\n"
 
 		if got != want {

--- a/web/web.go
+++ b/web/web.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"fmt"
+
 	"github.com/reverbdotcom/sbx/name"
 	"github.com/reverbdotcom/sbx/open"
 	"github.com/reverbdotcom/sbx/run"
@@ -11,7 +12,7 @@ const template = "https://%s.int.orchestra.rvb.ai/"
 
 var openURL = open.Open
 
-func Open() (string, error) {
+func Open(_ []string) (string, error) {
 	err := openURL(Url())
 
 	if err != nil {
@@ -23,7 +24,7 @@ func Open() (string, error) {
 
 var htmlUrlFn = run.HtmlUrl
 
-func OpenProgress() (string, error) {
+func OpenProgress(_ []string) (string, error) {
 	htmlUrl, err := htmlUrlFn()
 
 	if err != nil {

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -35,7 +35,7 @@ func TestOpen(t *testing.T) {
 			return nil
 		}
 
-		_, err := Open()
+		_, err := Open([]string{})
 
 		if err != nil {
 			t.Errorf("got %v, want nil", err)
@@ -47,7 +47,7 @@ func TestOpen(t *testing.T) {
 			return errors.New("open error")
 		}
 
-		_, err := Open()
+		_, err := Open([]string{})
 
 		want := "open error"
 		if err.Error() != want {
@@ -75,12 +75,11 @@ func TestOpenProgress(t *testing.T) {
 			return "progress.html", nil
 		}
 
-		_, err := OpenProgress()
+		_, err := OpenProgress([]string{})
 
 		if err != nil {
 			t.Errorf("got %v, want nil", err)
 		}
-
 	})
 
 	t.Run("errs on htmlUrlFn", func(t *testing.T) {
@@ -88,7 +87,7 @@ func TestOpenProgress(t *testing.T) {
 			return "", errors.New("htmlUrlFn error")
 		}
 
-		_, err := OpenProgress()
+		_, err := OpenProgress([]string{})
 
 		want := "htmlUrlFn error"
 		if err.Error() != want {
@@ -105,7 +104,7 @@ func TestOpenProgress(t *testing.T) {
 			return "progress.html", nil
 		}
 
-		_, err := OpenProgress()
+		_, err := OpenProgress([]string{})
 
 		want := "openURL error"
 		if err.Error() != want {


### PR DESCRIPTION
this adds `sbx help <cmd>` to get more info on what a command does (for example, what flags it accepts).

this is a precursor to add a `duration` flag to `up`, as this sets us up to add documented flags to the `up` command.

under the hood, this also adds the ability to parse additional args for each command (right now, only `help` uses this).