### PR TITLE
Add sbx db sidekiq

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,10 @@ export GOPRIVATE=github.com/reverbdotcom && go install github.com/reverbdotcom/s
 ```
 
 `sbx` now points to your branch version.
+
+Alternatively, you can build the project directly
+```bash
+go build -o /tmp/sbx .
+```
+
+and use `/tmp/sbx` in your orchestra-enabled repo.

--- a/db/db.go
+++ b/db/db.go
@@ -7,6 +7,7 @@ import (
 	"github.com/reverbdotcom/sbx/elasticsearch"
 	"github.com/reverbdotcom/sbx/postgres"
 	"github.com/reverbdotcom/sbx/redis"
+	"github.com/reverbdotcom/sbx/sidekiq"
 )
 
 const subcommandHelp = `USAGE:
@@ -16,6 +17,7 @@ SUBCOMMANDS:
   redis / r             opens the redis UI in a browser
   postgres / p / psql   opens the postgres UI in a browser
   elasticsearch / e / cerebro   opens the elasticsearch UI (cerebro) in a browser
+  sidekiq / s           opens the sidekiq UI in a browser
 
 If no subcommand is provided, shows this help.
 `
@@ -31,6 +33,8 @@ var subcommands = map[string]SubcommandFn{
 	"elasticsearch": elasticsearch.Open,
 	"e":             elasticsearch.Open,
 	"cerebro":       elasticsearch.Open,
+	"sidekiq":       sidekiq.Open,
+	"s":             sidekiq.Open,
 }
 
 var getArgs = func() []string {

--- a/sidekiq/sidekiq.go
+++ b/sidekiq/sidekiq.go
@@ -1,0 +1,29 @@
+package sidekiq
+
+import (
+	"fmt"
+
+	"github.com/reverbdotcom/sbx/name"
+	"github.com/reverbdotcom/sbx/open"
+	"github.com/reverbdotcom/sbx/run"
+)
+
+const template = "https://sidekiq-%s.int.orchestra.rvb.ai/"
+
+var openURL = open.Open
+
+func Open() (string, error) {
+	name, _ := nameFn()
+	url := fmt.Sprintf(template, name)
+	err := openURL(url)
+
+	if err != nil {
+		return "", err
+	}
+
+	return "", nil
+}
+
+var htmlUrlFn = run.HtmlUrl
+
+var nameFn = name.Name

--- a/sidekiq/sidekiq_test.go
+++ b/sidekiq/sidekiq_test.go
@@ -1,0 +1,43 @@
+package sidekiq
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestOpen(t *testing.T) {
+	name := "sandbox-foo-bar-baz"
+	nameFn = func() (string, error) { return name, nil }
+
+	t.Run("it opens url", func(t *testing.T) {
+		want := fmt.Sprintf(template, name)
+
+		openURL = func(got string) error {
+			if got != want {
+				t.Errorf("got %v, want %v", got, want)
+			}
+
+			return nil
+		}
+
+		_, err := Open()
+
+		if err != nil {
+			t.Errorf("got %v, want nil", err)
+		}
+	})
+
+	t.Run("it returns err", func(t *testing.T) {
+		openURL = func(_ string) error {
+			return errors.New("open error")
+		}
+
+		_, err := Open()
+
+		want := "open error"
+		if err.Error() != want {
+			t.Errorf("got %v, want %v", err, want)
+		}
+	})
+}

--- a/summary/summary.go
+++ b/summary/summary.go
@@ -20,6 +20,7 @@ Graphiql:       sbx g    | sbx graphiql
 Redis:          sbx db r | sbx db redis
 Postgres:       sbx db p | sbx db postgres
 Elasticsearch:  sbx db e | sbx db elasticsearch
+Sidekiq:        sbx db s | sbx db sidekiq
 
 Dash:           sbx d | sbx dash
 Logs:           sbx l | sbx logs

--- a/summary/summary_test.go
+++ b/summary/summary_test.go
@@ -30,6 +30,7 @@ Graphiql:       sbx g    | sbx graphiql
 Redis:          sbx db r | sbx db redis
 Postgres:       sbx db p | sbx db postgres
 Elasticsearch:  sbx db e | sbx db elasticsearch
+Sidekiq:        sbx db s | sbx db sidekiq
 
 Dash:           sbx d | sbx dash
 Logs:           sbx l | sbx logs


### PR DESCRIPTION
Adding `sbx db sidekiq` and `sbx db s` alias for easier sidekiq UI access in sandboxes.

Also included a small edit to the README to include instructions on making a temp local build for testing on orchestra